### PR TITLE
replace python2x.OrderedDict with collections.OrderedDict

### DIFF
--- a/src/models/deep_rnn.py
+++ b/src/models/deep_rnn.py
@@ -2,6 +2,7 @@
 import sys
 
 import numpy as np
+from collections import OrderedDict
 
 import theano
 import theano.tensor as T
@@ -155,7 +156,7 @@ class DeepRecurrentNetwork(object):
         
         
         # zip just concatenate two lists
-        updates = theano.compat.python2x.OrderedDict()
+        updates = OrderedDict()
         
         for param, gparam in zip(self.params, gparams):
             weight_update = self.updates[param]

--- a/src/models/dnn.py
+++ b/src/models/dnn.py
@@ -46,6 +46,7 @@ import sys
 import time
 
 import numpy
+from collections import OrderedDict
 
 import theano
 import theano.tensor as T
@@ -178,7 +179,7 @@ class DNN(object):
 
         if self.use_rprop == 0:
 
-            updates = theano.compat.python2x.OrderedDict()
+            updates = OrderedDict()
             layer_index = 0
             for dparam, gparam in zip(self.delta_params, gparams):
                 updates[dparam] = momentum * dparam - gparam * lr_list[layer_index]

--- a/src/models/exp_rnn.py
+++ b/src/models/exp_rnn.py
@@ -27,6 +27,7 @@
 import sys
 
 import numpy as np
+from collections import OrderedDict
 
 import theano
 import theano.tensor as T
@@ -219,7 +220,7 @@ class DeepRecurrentNetwork(object):
         
         
         # zip just concatenate two lists
-        updates = theano.compat.python2x.OrderedDict()
+        updates = OrderedDict()
         
         for param, gparam in zip(self.params, gparams):
             weight_update = self.updates[param]
@@ -266,7 +267,7 @@ class DeepRecurrentNetwork(object):
 
 
         # zip just concatenate two lists
-        updates = theano.compat.python2x.OrderedDict()
+        updates = OrderedDict()
 
         for param, gparam in zip(self.params, gparams):
             weight_update = self.updates[param]
@@ -315,7 +316,7 @@ class DeepRecurrentNetwork(object):
 
 
         # zip just concatenate two lists
-        updates = theano.compat.python2x.OrderedDict()
+        updates = OrderedDict()
 
         for param, gparam in zip(self.params, gparams):
             weight_update = self.updates[param]

--- a/src/models/mdn.py
+++ b/src/models/mdn.py
@@ -47,6 +47,7 @@ import time
 import math
 
 import numpy
+from collections import OrderedDict
 
 import theano
 import theano.tensor as T
@@ -228,7 +229,7 @@ class MixtureDensityNetwork(object):
 
         if self.use_rprop == 0:
         
-            updates = theano.compat.python2x.OrderedDict()
+            updates = OrderedDict()
             layer_index = 0
             for dparam, gparam in zip(self.delta_params, gparams):
                 updates[dparam] = momentum * dparam - gparam * lr_list[layer_index]

--- a/src/models/tpdnn.py
+++ b/src/models/tpdnn.py
@@ -43,6 +43,7 @@ import sys
 import time
 
 import numpy
+from collections import OrderedDict
 
 import theano
 import theano.tensor as T
@@ -266,7 +267,7 @@ class TokenProjectionDNN(object):
         gparams = T.grad(self.finetune_cost, self.params)
 
         def make_updates_plain(param_list, delta_param_list, gparam_list, lr_list, params_to_update):
-            updates = theano.compat.python2x.OrderedDict()
+            updates = OrderedDict()
             for dparam, gparam, lrate in zip(delta_param_list, gparam_list, lr_list):
                 updates[dparam] = momentum * dparam - gparam * lrate
             for dparam, param in zip(delta_param_list, param_list):
@@ -314,7 +315,7 @@ class TokenProjectionDNN(object):
         ##### OLDER VERSION:--
         '''
         ## All updates:
-        updates = theano.compat.python2x.OrderedDict()
+        updates = OrderedDict()
         layer_index = 0
         for dparam, gparam in zip(self.delta_params, gparams):
             updates[dparam] = momentum * dparam - gparam * lr_list[layer_index]
@@ -324,7 +325,7 @@ class TokenProjectionDNN(object):
             updates[param] = param + updates[dparam]
 
         ## These updates exclude parameters at 0 and 2  -- proj. weights and proj. half of split layer
-        subword_updates = theano.compat.python2x.OrderedDict()
+        subword_updates = OrderedDict()
         for (i, (dparam, gparam)) in enumerate(zip(self.delta_params, gparams)):
             if i not in [0,2]:  ## proj weights and proj half of split layer
                 subword_updates[dparam] = momentum * dparam - gparam * lr_list[i]
@@ -335,7 +336,7 @@ class TokenProjectionDNN(object):
 
         ## These updates exclude parameters at 1 -- subword half of split layer
         ### NO!!! -- just the word half of the split layer, and bias of that layer
-        word_updates = theano.compat.python2x.OrderedDict()
+        word_updates = OrderedDict()
         for (i, (dparam, gparam)) in enumerate(zip(self.delta_params, gparams)):
             if i in [0,2,3]:  
                 word_updates[dparam] = momentum * dparam - gparam * lr_list[i]
@@ -346,7 +347,7 @@ class TokenProjectionDNN(object):
 
 
         ## These updates exclude all but parameters at 0 -- projection layer
-        projection_updates = theano.compat.python2x.OrderedDict()
+        projection_updates = OrderedDict()
         for (i, (dparam, gparam)) in enumerate(zip(self.delta_params, gparams)):
             if i == 0: 
                 projection_updates[dparam] = momentum * dparam - gparam * lr_list[i]

--- a/src/training_schemes/rprop.py
+++ b/src/training_schemes/rprop.py
@@ -45,6 +45,7 @@ import matplotlib
 # Force matplotlib to not use any Xwindows backend.
 matplotlib.use('Agg')
 import  matplotlib.pyplot as plt
+from collections import OrderedDict
 
 def compile_RPROP_train_function(model, gparams, params_to_update=[]):
 
@@ -85,7 +86,7 @@ def compile_RPROP_train_function(model, gparams, params_to_update=[]):
 
     if model.use_rprop in [2,4]:
     
-        updates = theano.compat.python2x.OrderedDict()
+        updates = OrderedDict()
 
         for (i, (prev_gparam, gparam, update_step, param))  in enumerate(zip(model.previous_gparams, gparams, \
                                                         model.update_values, model.params)):


### PR DESCRIPTION
Recent theano package removed theano.compat.python2x module.
But, the current merlin still uses theano.compat.python2x.OrderedDict().

ref: https://github.com/Theano/Theano/commit/7ace6b7040d7e5ffb7ec64bfc8a2f4dee0a9aed1

I replaced "theano.compat.python2x.OrderedDict()" with "collections.OrderedDict()" to support the recent theano.
