### PR TITLE
htk_write_consistency_fix

### DIFF
--- a/src/io_funcs/htk_io.py
+++ b/src/io_funcs/htk_io.py
@@ -134,13 +134,13 @@ class HTK_Parm_IO(object):
             
             file = open(filename, 'wb')
             
-            file.write(struct.pack('>I', self.n_samples))
-            file.write(struct.pack('>I', self.samp_period))
-            file.write(struct.pack('>H', self.samp_size))
-            file.write(struct.pack('>H', self.param_kind))
+            file.write(struct.pack('<I', self.n_samples))
+            file.write(struct.pack('<I', self.samp_period))
+            file.write(struct.pack('<H', self.samp_size))
+            file.write(struct.pack('<H', self.param_kind))
             
-            if(sys.byteorder=='little'):
-                self.data.byteswap(True) # force big-endian byte ordering
+            #if(sys.byteorder=='little'):
+            #    self.data.byteswap(True) # force big-endian byte ordering
             
             self.data.tofile(file)
 


### PR DESCRIPTION
htk class reads as little endian without any control but forces to write as big endian. So If you write to a file and later read the very same file, the data is not the same.

It might be a matter of choice to write as big endian by default but I think this way is more consistent.
