### PR TITLE
Fix "lables" typo

### DIFF
--- a/egs/build_your_own_voice/s1/scripts/prepare_config_files.sh
+++ b/egs/build_your_own_voice/s1/scripts/prepare_config_files.sh
@@ -54,7 +54,7 @@ elif [ "$Labels" == "phone_align" ]
 then
     $SED -i s#'dur\s*:.*'#'dur: 1'# $duration_config_file
 else
-    echo "These labels ($Lables) are not supported as of now...please use state_align or phone_align!!"
+    echo "These labels ($Labels) are not supported as of now...please use state_align or phone_align!!"
 fi
 
 

--- a/egs/build_your_own_voice/s1/scripts/prepare_config_files_for_synthesis.sh
+++ b/egs/build_your_own_voice/s1/scripts/prepare_config_files_for_synthesis.sh
@@ -57,7 +57,7 @@ elif [ "$Labels" == "phone_align" ]
 then
     $SED -i s#'dur\s*:.*'#'dur: 1'# $duration_config_file
 else
-    echo "These labels ($Lables) are not supported as of now...please use state_align or phone_align!!"
+    echo "These labels ($Labels) are not supported as of now...please use state_align or phone_align!!"
 fi
 
 

--- a/egs/nick_hurricane/s1/scripts/prepare_config_files.sh
+++ b/egs/nick_hurricane/s1/scripts/prepare_config_files.sh
@@ -54,7 +54,7 @@ elif [ "$Labels" == "phone_align" ]
 then
     $SED -i s#'dur\s*:.*'#'dur: 1'# $duration_config_file
 else
-    echo "These labels ($Lables) are not supported as of now...please use state_align or phone_align!!"
+    echo "These labels ($Labels) are not supported as of now...please use state_align or phone_align!!"
 fi
 
 

--- a/egs/nick_hurricane/s1/scripts/prepare_config_files_for_synthesis.sh
+++ b/egs/nick_hurricane/s1/scripts/prepare_config_files_for_synthesis.sh
@@ -57,7 +57,7 @@ elif [ "$Labels" == "phone_align" ]
 then
     $SED -i s#'dur\s*:.*'#'dur: 1'# $duration_config_file
 else
-    echo "These labels ($Lables) are not supported as of now...please use state_align or phone_align!!"
+    echo "These labels ($Labels) are not supported as of now...please use state_align or phone_align!!"
 fi
 
 

--- a/egs/slt_arctic/s1/scripts/prepare_config_files.sh
+++ b/egs/slt_arctic/s1/scripts/prepare_config_files.sh
@@ -53,7 +53,7 @@ elif [ "$Labels" == "phone_align" ]
 then
     $SED -i s#'dur\s*:.*'#'dur: 1'# $duration_config_file
 else
-    echo "These labels ($Lables) are not supported as of now...please use state_align or phone_align!!"
+    echo "These labels ($Labels) are not supported as of now...please use state_align or phone_align!!"
 fi
 
 

--- a/egs/slt_arctic/s1/scripts/prepare_config_files_for_synthesis.sh
+++ b/egs/slt_arctic/s1/scripts/prepare_config_files_for_synthesis.sh
@@ -57,7 +57,7 @@ elif [ "$Labels" == "phone_align" ]
 then
     $SED -i s#'dur\s*:.*'#'dur: 1'# $duration_config_file
 else
-    echo "These labels ($Lables) are not supported as of now...please use state_align or phone_align!!"
+    echo "These labels ($Labels) are not supported as of now...please use state_align or phone_align!!"
 fi
 
 


### PR DESCRIPTION
All the `prepare_config_files` scripts had a typo:

s/Lables/Labels

(please squash and merge, I did the edits from the web browser -- that's why there are individual commits)