### PR TITLE
label normalization: Fix wildcard handling bug

### DIFF
--- a/src/frontend/label_normalisation.py
+++ b/src/frontend/label_normalisation.py
@@ -797,16 +797,18 @@ class HTSLabelNormalisation(LabelNormalisation):
         """
 
         ## handle HTK wildcards (and lack of them) at ends of label:
+        prefix = ""
+        postfix = ""
         if '*' in question:
             if not question.startswith('*'):
-                question = '\A' + question
+                prefix = "\A"
             if not question.endswith('*'):
-                question = question + '\Z'
+                postfix = "\Z"
         question = question.strip('*')
         question = re.escape(question)
         ## convert remaining HTK wildcards * and ? to equivalent regex:
         question = question.replace('\\*', '.*')
-        #question = question.replace('\\?', '.?')
+        question = prefix + question + postfix
 
         if convert_number_pattern:
             question = question.replace('\\(\\\\d\\+\\)', '(\d+)')


### PR DESCRIPTION
The problem was that `\A` and `\Z` were escaped, so those didn't work at all as regular expressions. This was found when I was trying to use a question file from HTS-NIT-ATR503 demo for Japanese TTS.

cross-ref: https://github.com/r9y9/nnmnkwii/pull/17