### PR TITLE
Fix python3 import error

### DIFF
--- a/src/utils/file_paths.py
+++ b/src/utils/file_paths.py
@@ -19,8 +19,8 @@
 __author__ = 'pasindu@google.com (Pasindu De Silva)'
 
 import os
-from utils import prepare_file_path_list
-from utils import read_file_list
+from .utils import prepare_file_path_list
+from .utils import read_file_list
 
 
 class FilePaths(object):
@@ -182,6 +182,6 @@ class FilePaths(object):
 
   def _prepare_test_label_file_path_list(self, list_dir):
     return prepare_file_path_list(self.test_id_list, list_dir, self.cfg.lab_ext)
-  
+
   def _prepare_test_binary_label_file_path_list(self, list_dir):
     return prepare_file_path_list(self.test_id_list, list_dir, self.cfg.lab_ext+'bin')


### PR DESCRIPTION
```
 File "/home/ryuichi/Dropbox/sp/merlin_pr/src/utils/file_paths.py",
 line 22, in <module>
     from utils import prepare_file_path_list
     ImportError: cannot import name 'prepare_file_path_list'
```

This is because there are two `utils` modules in merlin, src/utils
and src/utils/utils. Fixing this by explicitly importing the module
we need.

Seems to be caused by #220.

EDIT: The above error happened when I tried to run `slt_arctic` demo.
