### PR TITLE
Towards continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.6"
+
+notifications:
+  email: false
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install csh realpath autotools-dev automake
+  - ./tools/compile_tools.sh
+  - if [["$TRAVIS_PYTHON_VERSION" == "2.7"]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda config --add channels pypi
+  - conda info -a
+  - deps='pip numpy scipy nose'
+  - conda create -q -n test-environment "python=$TRAVIS_PYTHON_VERSION" $deps
+  - source activate test-environment
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - cd $TRAVIS_BUILD_DIR/egs/slt_arctic/s1 && ./run_demo.sh


### PR DESCRIPTION
Ref: https://github.com/CSTR-Edinburgh/merlin/pull/249#issuecomment-331635667

As a first step towards continuous integration testing, this PR adds testing infrastructure using https://travis-ci.org/. I have written a simple build and test script, which runs slt_arctic_demo on travis. More unit tests can be added later.

With this, we can ensure that Merlin should work on standard linux distributions at least ubuntu with both python2.7 and python3.6 continuously and prevent bugs which may be introduced unexpectedly (e.g., see #252).

I've confirmed tests are running correctly on my travis account: https://travis-ci.org/r9y9/merlin/builds/290322642. If this is an acceptable change,  someone who has ownership of the repository needs to signup travis and activate CI.