### PR TITLE
Fix a potential mismatch between test_id_list and gen_test_file_list

### DIFF
--- a/src/keras_lib/train.py
+++ b/src/keras_lib/train.py
@@ -260,14 +260,12 @@ class TrainKerasModels(kerasModels):
         #### compute predictions ####
         io_funcs = BinaryIOCollection()
 
-        test_id_list = list(test_x.keys())
-        test_id_list.sort()
-
-        test_file_number = len(test_id_list)
+        test_file_number = len(gen_test_file_list)
         print("generating features on held-out test data...")
         for utt_index in range(test_file_number):
             gen_test_file_name = gen_test_file_list[utt_index]
-            temp_test_x        = test_x[test_id_list[utt_index]]
+            test_id = os.path.splitext(os.path.basename(gen_test_file_name))[0]
+            temp_test_x        = test_x[test_id]
             num_of_rows        = temp_test_x.shape[0]
 
             if stateful:


### PR DESCRIPTION
Hi, this is really a minor issue but it can be annoying when it happens. When using Keras, at the DNNGEN step, the function predict stores the label data in a dictionary text_x whose keys are the ids of the label files  in gen_test_file_list. Since the dict is unordered, it sorts the list of file ids to retrieve the order of the files in gen_test_file_list. However this assumes that gen_test_file_list is ordered alphabetically which is not always the case (it is sorted by date of modification, at least on my system). For instance, I'm trying to use magphase, which requires to modify the label files, and I'm doing this modification via parallel processing that breaks the natural oder of the label files. Then of course, things will not go very well when predicting the durations...

One fix could be to use an ordered dict but it's even simpler to just retrieve the file ids from the list of file names, that's the small modification proposed below.

Thanks.