### PR TITLE
Add code : Support old HTS question file format

### DIFF
--- a/src/frontend/label_normalisation.py
+++ b/src/frontend/label_normalisation.py
@@ -844,7 +844,7 @@ class HTSLabelNormalisation(LabelNormalisation):
         LL=re.compile(re.escape('LL-'))
 
         for line in fid.readlines():
-            line = line.replace('\n', '')
+            line = line.replace('\n', '').replace('\t', ' ')
 
             if len(line) > 5:
                 temp_list = line.split('{')


### PR DESCRIPTION
Some HTS question files use '\t' as the separator.