### PR TITLE
potential fix for #245

### DIFF
--- a/src/layers/gating.py
+++ b/src/layers/gating.py
@@ -841,7 +841,7 @@ class BidirectionSLstm(SimplifiedLstm):
 
         self.params = fwd.params + bwd.params
 
-        self.output = T.concatenate([fwd.output, bwd.output[::-1]], axis=1)
+        self.output = T.concatenate([fwd.output, bwd.output[::-1]], axis=-1)
 
 class BidirectionLstm(VanillaLstm):
 
@@ -852,7 +852,7 @@ class BidirectionLstm(VanillaLstm):
 
         self.params = fwd.params + bwd.params
 
-        self.output = T.concatenate([fwd.output, bwd.output[::-1]], axis=1)
+        self.output = T.concatenate([fwd.output, bwd.output[::-1]], axis=-1)
 
 
 class RecurrentOutput(object):


### PR DESCRIPTION
With batches, the shapes are now: (batch_size, length, features) whereas it was (length, features). The concatenation axis has to be the dimension 2 now, whereas it was the dimension 1 previously. Using the last dimension (-1) do the trick, for both cases.