### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,7 +54,7 @@ sudo apt-get install python-numpy python-scipy python-dev python-pip python-nose
 
 #### For Fedora: 
 ```sh
-sudo yum install python-numpy python-scipy python-dev python-pip python-nose g++ libopenblas-dev git libc6-dev-i386 glibc-devel.i686 csh python-lxml libxslt-devel
+sudo yum install python-numpy python-scipy python-dev python-pip python-nose g++ libopenblas-dev git libc6-dev-i386 glibc-devel.i686 csh python-lxml libxslt-devel unzip
 ```
 
 #### Common libraries for both Ubuntu and Fedora:


### PR DESCRIPTION
Add `unzip` to the list of linux dependencies

`unzip` is required by scripts like  [egs/slt_arctic/s1/01_setup.sh](merlin/egs/slt_arctic/s1/01_setup.sh ).
However, not all distributions have `unzip` installed by default.

