### PR TITLE
BLSTM implementation in keras_lib

### DIFF
--- a/src/keras_lib/model.py
+++ b/src/keras_lib/model.py
@@ -178,14 +178,6 @@ class kerasModels(object):
                         batch_input_shape=(batch_size, timesteps, input_size),
                         return_sequences=True,
                         stateful=True))   #go_backwards=True))
-            elif self.hidden_layer_type[i]=='blstm':
-                self.model.add(LSTM(
-                        units=self.hidden_layer_size[i],
-                        batch_input_shape=(batch_size, timesteps, input_size),
-                        return_sequences=True,
-                        stateful=True,
-                        go_backwards=True))
-                
             elif self.hidden_layer_type[i] == 'blstm':
                 self.model.add(Bidirectional(LSTM(
                         units=self.hidden_layer_size[i],

--- a/src/keras_lib/model.py
+++ b/src/keras_lib/model.py
@@ -185,6 +185,14 @@ class kerasModels(object):
                         return_sequences=True,
                         stateful=True,
                         go_backwards=True))
+                
+            elif self.hidden_layer_type[i] == 'blstm':
+                self.model.add(Bidirectional(LSTM(
+                        units=self.hidden_layer_size[i],
+                        return_sequences=True,
+                        stateful=True),
+                    batch_input_shape=(batch_size, timesteps, input_size),
+                    merge_mode='concat'))
             else:
                 self.model.add(Dense(
                         units=self.hidden_layer_size[i],

--- a/src/keras_lib/model.py
+++ b/src/keras_lib/model.py
@@ -134,12 +134,12 @@ class kerasModels(object):
                         units=self.hidden_layer_size[i],
                         input_shape=(None, input_size),
                         return_sequences=True))
-            elif self.hidden_layer_type[i]=='blstm':
-                self.model.add(LSTM(
+            elif self.hidden_layer_type[i] == 'blstm':
+                self.model.add(Bidirectional(LSTM(
                         units=self.hidden_layer_size[i],
-                        input_shape=(None, input_size),
-                        return_sequences=True,
-                        go_backwards=True))
+                        return_sequences=True),
+                    input_shape=(None, input_size),
+                    merge_mode='concat'))
             else:
                 self.model.add(Dense(
                         units=self.hidden_layer_size[i],


### PR DESCRIPTION
Hi,

it seems that the current blstm implementation in keras_lib is just a backwards lstm and not a bidirectional lstm. This pull request fixes this, using the `Bidirectional` keras wrapper (https://keras.io/layers/wrappers/)

p.s: The code has been tested for the sequence model but not the stateful model.