### PR TITLE
Update label_normalization.py

### DIFF
--- a/src/frontend/label_normalisation.py
+++ b/src/frontend/label_normalisation.py
@@ -842,6 +842,7 @@ class HTSLabelNormalisation(LabelNormalisation):
         binary_dict = {}
         continuous_dict = {}
         LL=re.compile(re.escape('LL-'))
+        LAST_QUESTION = re.compile(re.escape('(\d+)') + '$') # regex for last question
 
         for line in fid.readlines():
             line = line.replace('\n', '').replace('\t', ' ')
@@ -860,6 +861,8 @@ class HTSLabelNormalisation(LabelNormalisation):
                 if temp_list[0] == 'CQS':
                     assert len(question_list) == 1
                     processed_question = self.wildcards2regex(question_list[0], convert_number_pattern=True)
+                    if LAST_QUESTION.search(question_list[0]):
+                        processed_question = processed_question + '$' # last question must only match at end of HTS label string
                     continuous_dict[str(continuous_qs_index)] = re.compile(processed_question) #save pre-compiled regular expression
                     continuous_qs_index = continuous_qs_index + 1
                 elif temp_list[0] == 'QS':


### PR DESCRIPTION
Added end of string ('$') regex for last question in question set. This ensures that the last question only matches at the end of the HTS label string

This is to sort out issue #434 

To test:
* run `merlin/egs/slt_arctic/s1/` recipe (demo is fine) just for duration model training
* make a copy of `merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/duration_model/inter_module/binary_label_416`
to `merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/duration_model/inter_module/binary_label_416_changed`
* comment out lines 864 and 865 of `merlin/src/frontend/label_normalization.py`
* run `merlin/egs/slt_arctic/s1/` recipe (demo is fine) just for duration model training
* dump the `arctic_0060.lab` file to text for both versions
    - ```dmp +fa merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/duration_model/inter_module/binary_label_416/arctic_a0060.lab >  merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/duration_model/inter_module/binary_label_416/arctic_a0060.txt```
     - ```dmp +fa merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/duration_model/inter_module/binary_label_416_changed/arctic_a0060.lab >  merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/duration_model/inter_module/binary_label_416_changed/arctic_a0060.txt```
* check the difference
 ```diff merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/duration_model/inter_module/binary_label_416/arctic_a0060.txt merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/duration_model/inter_module/binary_label_416_changed/arctic_a0060.txt```

In the second file the last element of each label (the 416th) stays the same, whilst in the first file it differs between labels. The last element should be the same for each label as can be seen from `merlin/egs/slt_arctic/s1/experiments/slt_arctic_demo/acoustic_model/data/label_state_align/arctic_a0060.lab`.

 