### PR TITLE
Fixed frame number calculation to work for Python 2.x and 3.x (using floor division)

### DIFF
--- a/misc/scripts/alignment/state_align/binary_io.py
+++ b/misc/scripts/alignment/state_align/binary_io.py
@@ -9,7 +9,7 @@ class   BinaryIOCollection(object):
         features = numpy.fromfile(fid_lab, dtype=numpy.float32)
         fid_lab.close()
         assert features.size % float(dimension) == 0.0,'specified dimension not compatible with data'
-        features = features[:(dimension * (features.size / dimension))]
+        features = features[:(dimension * (features.size // dimension))]
         features = features.reshape((-1, dimension))
 
         return  features
@@ -26,7 +26,7 @@ class   BinaryIOCollection(object):
         features = numpy.fromfile(fid_lab, dtype=numpy.float32)
         fid_lab.close()
         assert features.size % float(dimension) == 0.0,'specified dimension not compatible with data'
-        frame_number = features.size / dimension
+        frame_number = features.size // dimension
         features = features[:(dimension * frame_number)]
         features = features.reshape((-1, dimension))
 

--- a/misc/scripts/voice_conversion/binary_io.py
+++ b/misc/scripts/voice_conversion/binary_io.py
@@ -9,7 +9,7 @@ class   BinaryIOCollection(object):
         features = numpy.fromfile(fid_lab, dtype=numpy.float32)
         fid_lab.close()
         assert features.size % float(dimension) == 0.0,'specified dimension not compatible with data'
-        features = features[:(dimension * (features.size / dimension))]
+        features = features[:(dimension * (features.size // dimension))]
         features = features.reshape((-1, dimension))
 
         return  features
@@ -26,7 +26,7 @@ class   BinaryIOCollection(object):
         features = numpy.fromfile(fid_lab, dtype=numpy.float32)
         fid_lab.close()
         assert features.size % float(dimension) == 0.0,'specified dimension not compatible with data'
-        frame_number = features.size / dimension
+        frame_number = features.size // dimension
         features = features[:(dimension * frame_number)]
         features = features.reshape((-1, dimension))
 
@@ -37,7 +37,7 @@ class   BinaryIOCollection(object):
         features = numpy.fromfile(fid_lab, dtype="int32")
         fid_lab.close()
         assert features.size % float(dimension) == 0.0,'specified dimension not compatible with data'
-        frame_number = features.size / dimension
+        frame_number = features.size // dimension
         features = features[:(dimension * frame_number)]
         features = features.reshape((-1, dimension))
         


### PR DESCRIPTION
Now frame number in all binary_io.py versions across the repo should use classic Python 2.x floor division

Addresses #448 