### PR TITLE
Segfault Fix: Added isnan() check for tentative_f0 in GetTentativeF0 to WORLD's analysis tool

### DIFF
--- a/tools/WORLD/src/stonemask.cpp
+++ b/tools/WORLD/src/stonemask.cpp
@@ -126,7 +126,7 @@ static double GetTentativeF0(const double *power_spectrum, const double *numerat
     FixF0(power_spectrum, numerator_i, fft_size, fs, f0_initial, 2);
 
   // If the fixed value is too large, the result will be rejected.
-  if (tentative_f0 <= 0.0 || tentative_f0 > f0_initial * 2)
+  if (tentative_f0 <= 0.0 || tentative_f0 > f0_initial * 2 || isnan(tentative_f0))
     return 0.0;
 
   return FixF0(power_spectrum, numerator_i, fft_size, fs, tentative_f0, 6);


### PR DESCRIPTION
thus rejecting nan/-nan tentative_f0 values. Got these on large (50s) WAVs of synthesized speech.

