### PR TITLE
remove deprecated string class method call

### DIFF
--- a/src/logplot/logging_plotting.py
+++ b/src/logplot/logging_plotting.py
@@ -256,7 +256,7 @@ class LoggerPlotter(logging.getLoggerClass()):
             # TO DO - need to be sure of safe file names
             if not os.path.isdir(self.plot_path):
                 os.makedirs(self.plot_path)
-            filename = self.plot_path + "/" + string.replace(plot_name, " ", "_") + ".pdf"
+            filename = self.plot_path + "/" + plot_name.replace(" ", "_") + ".pdf"
             logger.info('Generating a plot in file %s' % filename)
             self.plots[plot_name].generate_plot(filename,**kwargs)
             # else:


### PR DESCRIPTION
Replaced a call to a deprecated string method which caused the code to fail in python 3.
Only line 259 of src/logplot/logging_plotting.py is modified

Here is an example of a stack trace
>   File "./merlin/src/run_merlin.py", line 1320, in <module>
>     main_function(cfg)
>   File "./merlin/src/run_merlin.py", line 870, in main_function
>     cmp_mean_vector = cmp_mean_vector, cmp_std_vector = cmp_std_vector,init_dnn_model_file=cfg.start_from_trained_model)
>   File "./merlin/src/run_merlin.py", line 382, in train_DNN
>     plotlogger.save_plot('training convergence',title='Progress of training and validation error',xlabel='epochs',ylabel='error')
>   File "/xxx/merlin/src/logplot/logging_plotting.py", line 259, in save_plot
>     filename = self.plot_path + "/" + string.replace(plot_name, " ", "_") + ".pdf"
> AttributeError: module 'string' has no attribute 'replace'
