### PR TITLE
fix: TypeError of run_merlin.py

### DIFF
--- a/src/run_merlin.py
+++ b/src/run_merlin.py
@@ -1291,7 +1291,7 @@ if __name__ == '__main__':
 
     logger.info('Execution information:')
     logger.info('  HOSTNAME: '+socket.getfqdn())
-    logger.info('  USER: '+os.getenv('USER'))
+    logger.info('  USER: '+str(os.getenv('USER')))
     logger.info('  PID: '+str(os.getpid()))
     PBS_JOBID = os.getenv('PBS_JOBID')
     if PBS_JOBID:

--- a/src/setup_env.sh
+++ b/src/setup_env.sh
@@ -10,7 +10,7 @@ export PYTHONBIN="python"
 #export LD_LIBRARY_PATH=/anotherpath:LD_LIBRARY_PATH
 
 # Basic Theano flags
-MERLIN_THEANO_FLAGS="cuda.root=/usr/local/8.0,floatX=float32,on_unused_input=ignore"
+MERLIN_THEANO_FLAGS="cuda.root=/usr/local/cuda-10.2,floatX=float32,on_unused_input=ignore,gpuarray.preallocate=0.90"
 export MERLIN_THEANO_FLAGS
 	
 


### PR DESCRIPTION
using Python 3.6.10
Fixed "TypeError: must be str, not NoneType" error that occurs in logger.info of run_merlin.py.